### PR TITLE
fix(Vditor): fix error of editor.destroy

### DIFF
--- a/src/components/Standard/StandardVditorEditor.tsx
+++ b/src/components/Standard/StandardVditorEditor.tsx
@@ -284,7 +284,7 @@ export function VditorEditor({ id, after, input }: Props) {
     }
 
     return () => {
-      editor.destroy();
+      document.querySelector('.vditor') && editor.destroy();
     };
   }, []);
 


### PR DESCRIPTION
editor.destroy会移除所有.editor编辑器, 习题编辑页面有三个编辑器, 后两个调用destroy出错.